### PR TITLE
Update helm-unittest.sh

### DIFF
--- a/bin/helm-unittest.sh
+++ b/bin/helm-unittest.sh
@@ -8,4 +8,4 @@ if which helm &> /dev/null $? != 0 ; then
     exit 1
 fi
 
-helm unittest -3 .
+helm unittest .

--- a/bin/helm-unittest.sh
+++ b/bin/helm-unittest.sh
@@ -8,4 +8,4 @@ if which helm &> /dev/null $? != 0 ; then
     exit 1
 fi
 
-helm unittest .
+helm unittest $@


### PR DESCRIPTION
`-3` flag is no longer needed and causes an error with the latest unittest plugin